### PR TITLE
Remember selected player

### DIFF
--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -115,9 +115,4 @@
         }
     }
 
-- ( void ) terminate
-    {
-        [ NSApp terminate : nil ];
-    }
-
     @end

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -57,7 +57,8 @@
         menu.itemArray[Spotify].enabled = (spotifyApplication != nil);
 
         [ menu addItem : [ NSMenuItem separatorItem ] ]; // A thin grey line
-        [ menu addItemWithTitle : @"Quit" action : @selector(terminate:) keyEquivalent : @"" ];
+        NSString *appName = [NSBundle mainBundle].infoDictionary[@"CFBundleName"];
+        [ menu addItemWithTitle : [NSString stringWithFormat: @"Quit %@", appName] action : @selector(terminate:) keyEquivalent : @"" ];
 
         NSImage* image = [ NSImage imageNamed : @"mak" ];
         [ image setTemplate : YES ];

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -1,9 +1,11 @@
 
     #import "AppDelegate.h"
 
+    static NSString* const kSelectedApplication = @"selectedApplication";
+
     typedef enum : NSUInteger {
-        iTunes = 0,
-        Spotify = 1
+        iTunes = 1,
+        Spotify = 2
     } PlayerApplicationTag;
 
 
@@ -18,19 +20,24 @@
 
     @implementation AppDelegate
 
-    - (void) switchStandardApplication:(NSMenuItem*) toSwitchItem {
-        if (toSwitchItem.tag == iTunes) {
+    - (void)switchStandardApplication:(NSMenuItem*) menuItem {
+        [self switchStandardApplicationTag:menuItem.tag];
+    }
+
+    - (void) switchStandardApplicationTag:(NSUInteger) tag {
+        [[NSUserDefaults standardUserDefaults] setInteger:tag forKey:kSelectedApplication];
+        
+        if (tag == iTunes) {
             standardApplication = _iTunesApplication;
-            NSLog(@"Use iTunes");
-        } else if (toSwitchItem.tag == Spotify && spotifyApplication) {
+        } else if (tag == Spotify && spotifyApplication) {
             standardApplication = spotifyApplication;
-            NSLog(@"Use Spotify");
         } else {
-            //something went really wrong
+            tag = iTunes;
             standardApplication = _iTunesApplication;
         }
+        
         for (NSMenuItem* item in statusItem.menu.itemArray) {
-            if (item == toSwitchItem) {
+            if (item.tag == tag) {
                 item.state = NSOnState;
             } else {
                 item.state = NSOffState;
@@ -47,14 +54,12 @@
         NSMenu *menu = [ [ NSMenu alloc ] init ];
         menu.autoenablesItems = NO;
         
-        [menu insertItemWithTitle : @"iTunes" action : @selector(switchStandardApplication:) keyEquivalent:@"" atIndex: iTunes];
-        menu.itemArray[iTunes].tag = iTunes;
-        menu.itemArray[iTunes].state = NSOnState;
+        [menu addItemWithTitle : @"iTunes" action : @selector(switchStandardApplication:) keyEquivalent:@""];
+        menu.itemArray.lastObject.tag = iTunes;
         
-        [menu insertItemWithTitle : @"Spotify" action : @selector(switchStandardApplication:) keyEquivalent:@"" atIndex: Spotify];
-        menu.itemArray[Spotify].tag = Spotify;
-        menu.itemArray[Spotify].state = NSOffState;
-        menu.itemArray[Spotify].enabled = (spotifyApplication != nil);
+        [menu addItemWithTitle : @"Spotify" action : @selector(switchStandardApplication:) keyEquivalent:@""];
+        menu.itemArray.lastObject.tag = Spotify;
+        menu.itemArray.lastObject.enabled = (spotifyApplication != nil);
 
         [ menu addItem : [ NSMenuItem separatorItem ] ]; // A thin grey line
         NSString *appName = [NSBundle mainBundle].infoDictionary[@"CFBundleName"];
@@ -67,6 +72,10 @@
         [ statusItem setToolTip : @"High Sierra Media Key Enabler" ];
         [ statusItem setMenu : menu ];
         [ statusItem setImage : image ];
+
+        // This will default to 0, and switchStandardApplication will default to using iTunes
+        NSInteger selectedApplicationTag = [[NSUserDefaults standardUserDefaults] integerForKey:kSelectedApplication];
+        [self switchStandardApplicationTag:selectedApplicationTag];
         
         keyTap = [[SPMediaKeyTap alloc] initWithDelegate:self];
         if([SPMediaKeyTap usesGlobalMediaKeyTap])

--- a/HighSierraMediaKeyEnabler/AppDelegate.m
+++ b/HighSierraMediaKeyEnabler/AppDelegate.m
@@ -45,19 +45,16 @@
         standardApplication = _iTunesApplication;
         
         NSMenu *menu = [ [ NSMenu alloc ] init ];
+        menu.autoenablesItems = NO;
+        
         [menu insertItemWithTitle : @"iTunes" action : @selector(switchStandardApplication:) keyEquivalent:@"" atIndex: iTunes];
         menu.itemArray[iTunes].tag = iTunes;
         menu.itemArray[iTunes].state = NSOnState;
         
-        if (spotifyApplication) {
-            [menu insertItemWithTitle : @"Spotify" action : @selector(switchStandardApplication:) keyEquivalent:@"" atIndex: Spotify];
-            menu.itemArray[Spotify].tag = Spotify;
-            menu.itemArray[Spotify].state = NSOffState;
-        } /*else {
-            // for a consistent GUI we may need this line
-            [menu addItemWithTitle:@"Spotify not installed" action:nil keyEquivalent:@""];
-        }*/
-
+        [menu insertItemWithTitle : @"Spotify" action : @selector(switchStandardApplication:) keyEquivalent:@"" atIndex: Spotify];
+        menu.itemArray[Spotify].tag = Spotify;
+        menu.itemArray[Spotify].state = NSOffState;
+        menu.itemArray[Spotify].enabled = (spotifyApplication != nil);
 
         [ menu addItem : [ NSMenuItem separatorItem ] ]; // A thin grey line
         [ menu addItemWithTitle : @"Quit" action : @selector(terminate:) keyEquivalent : @"" ];
@@ -80,8 +77,6 @@
 
     -(void)mediaKeyTap:(SPMediaKeyTap*)keyTap receivedMediaKeyEvent:(NSEvent*)event;
     {
-        //iTunesApplication* iTunesApplication = [SBApplication applicationWithBundleIdentifier:@"com.apple.iTunes"];
-        //SpotifyApplication *spotifyApplication = [SBApplication applicationWithBundleIdentifier:@"com.spotify.client"];
         NSAssert([event type] == NSSystemDefined && [event subtype] == SPSystemDefinedEventMediaKeys, @"Unexpected NSEvent in mediaKeyTap:receivedMediaKeyEvent:");
         // here be dragons...
         int keyCode = (([event data1] & 0xFFFF0000) >> 16);
@@ -92,22 +87,16 @@
             switch (keyCode) {
                 case NX_KEYTYPE_PLAY:
                     [standardApplication playpause];
-                    //if (defaultPlayer == iTunes) [iTunesApplication playpause];
-                    //if ( [iTunesApplication isRunning ] && defaultPlayer == iTunes) [iTunesApplication playpause];
-                    //if ( [spotifyApplication isRunning ] ) [spotifyApplication playpause];
                     break;
                     
                 case NX_KEYTYPE_FAST:
                     [standardApplication nextTrack];
-                    //if ( [iTunesApplication isRunning ] && defaultPlayer == iTunes) [iTunesApplication nextTrack];
-                    //if ( [spotifyApplication isRunning ] ) [spotifyApplication nextTrack];
                     break;
                     
                 case NX_KEYTYPE_REWIND:
                     [standardApplication previousTrack];
-                    //if ( [iTunesApplication isRunning ] && defaultPlayer == iTunes) [iTunesApplication previousTrack];
-                    //if ( [spotifyApplication isRunning ] ) [spotifyApplication previousTrack];
                     break;
+
                 default:
                     break;
                     // More cases defined in hidsystem/ev_keymap.h

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://travis-ci.org/michaeldorner/ByteBackpacker.svg)](https://travis-ci.org/michaeldorner/ByteBackpacker)
+[![Build Status](https://travis-ci.org/milgra/HighSierraMediaKeyEnabler.svg)](https://travis-ci.org/milgra/HighSierraMediaKeyEnabler)
 
 # HighSierraMediaKeyEnabler
 
-> MacOS High Sierra Media Key Enabler for iTunes
+> macOS High Sierra Media Key Enabler for iTunes/Spotify
 
-It only works with physical buttons, won't work with touchbar. The small app detects if Spotify is installed and offers to switch between controlling iTunes and Spotify.
+It only works with physical buttons, won't work with the TouchBar. This small app detects if Spotify is installed and offers to switch between controlling iTunes and Spotify.
 
-I don't have a developer certificate so trust the app when MacOS asks. Feel free to compile the project yourself.
+I don't have a developer certificate so trust the app when macOS asks. Feel free to compile the project yourself.


### PR DESCRIPTION
I've been using your fork of highsierramediakeyenabler for a while (thanks!). I reboot my machine quite a bit and manually selecting Spotify every time was getting tedious, so I've made the app remember the last selected player using `NSUserDefaults`.
I've massaged the code a bit so that adding more players in the future should be straightforward as well.

Since your PR for the original project is still open, I thought I'd send a PR here and if you find some bits useful, you can merge or cherry-pick them so they'll become part of your PR.